### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build_STITCH_docker.yml
+++ b/.github/workflows/build_STITCH_docker.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Build Tools
     - name: Build and Publish
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sjwidmay/stitch_nf
         username: ${{ secrets.SJW_DOCKER_USER }}

--- a/.github/workflows/build_StatMarkdown.yml
+++ b/.github/workflows/build_StatMarkdown.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Build Tools
     - name: Build and Publish
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sjwidmay/stitch_nf
         username: ${{ secrets.SJW_DOCKER_USER }}

--- a/.github/workflows/build_bbtools_docker.yml
+++ b/.github/workflows/build_bbtools_docker.yml
@@ -18,7 +18,7 @@ jobs:
 
     # Build Tools
     - name: Build and Publish
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sjwidmay/stitch_nf
         username: ${{ secrets.SJW_DOCKER_USER }}

--- a/.github/workflows/build_fastp_docker.yml
+++ b/.github/workflows/build_fastp_docker.yml
@@ -18,7 +18,7 @@ jobs:
 
     # Build Tools
     - name: Build and Publish
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sjwidmay/fastp_nf
         username: ${{ secrets.SJW_DOCKER_USER }}

--- a/.github/workflows/build_stacks_docker.yml
+++ b/.github/workflows/build_stacks_docker.yml
@@ -18,7 +18,7 @@ jobs:
 
     # Build Tools
     - name: Build and Publish
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sjwidmay/stitch_nf
         username: ${{ secrets.SJW_DOCKER_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore